### PR TITLE
Pass any type for migrations

### DIFF
--- a/apps/server/database/create-migration.ts
+++ b/apps/server/database/create-migration.ts
@@ -23,9 +23,9 @@ const content = `
 import { Kysely, sql } from 'kysely'
 import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {}
+export async function up(db: Kysely<any>): Promise<void> {}
 
-export async function down(db: Kysely<Database>): Promise<void> {}
+export async function down(db: Kysely<any>): Promise<void> {}
 `
 
 fs.writeFile(path + filename, content, err => {

--- a/apps/server/database/migrations/202305222148-add-create-todo.ts
+++ b/apps/server/database/migrations/202305222148-add-create-todo.ts
@@ -1,8 +1,7 @@
 // migration 2023-05-22, 21:48
 import { Kysely, sql } from 'kysely'
-import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .createTable('todo')
         .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
@@ -12,6 +11,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
         .execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema.dropTable('todo').execute()
 }

--- a/apps/server/database/migrations/202306171357-add-user.ts
+++ b/apps/server/database/migrations/202306171357-add-user.ts
@@ -1,8 +1,7 @@
 // migration 2023-06-17, 13:57
 import { Kysely, sql } from 'kysely'
-import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .createTable('user')
         .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
@@ -12,6 +11,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
         .execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema.dropTable('user').execute()
 }

--- a/apps/server/database/migrations/202306251948-add-session.ts
+++ b/apps/server/database/migrations/202306251948-add-session.ts
@@ -1,8 +1,7 @@
 // migration 2023-06-25, 19:48
 import { Kysely, sql } from 'kysely'
-import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .createTable('session')
         .ifNotExists()
@@ -16,6 +15,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
         .execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema.dropTable('session').execute()
 }

--- a/apps/server/database/migrations/202306280850-add-footprint.ts
+++ b/apps/server/database/migrations/202306280850-add-footprint.ts
@@ -1,8 +1,7 @@
 // migration 2023-06-28, 08:50
 import { Kysely, sql } from 'kysely'
-import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .createTable('footprint')
         .ifNotExists()
@@ -14,6 +13,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
         .execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema.dropTable('footprint').execute()
 }

--- a/apps/server/database/migrations/202307081653-add-webauthn.ts
+++ b/apps/server/database/migrations/202307081653-add-webauthn.ts
@@ -1,8 +1,7 @@
 // migration 2023-07-08, 16:53
 import { Kysely, sql } from 'kysely'
-import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .createTable('webauthn')
         .ifNotExists()
@@ -17,6 +16,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
         .execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema.dropTable('webauthn').execute()
 }

--- a/apps/server/database/migrations/202307081659-update-user.ts
+++ b/apps/server/database/migrations/202307081659-update-user.ts
@@ -1,14 +1,13 @@
 // migration 2023-07-08, 16:59
-import type { Database } from '../index'
 import { Kysely } from 'kysely'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .alterTable('user')
         .addColumn('webauthn', 'boolean', col => col.notNull().defaultTo(false))
         .execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema.alterTable('user').dropColumn('webauthn').execute()
 }

--- a/apps/server/database/migrations/202308131507-add-webauthn-to-user.ts
+++ b/apps/server/database/migrations/202308131507-add-webauthn-to-user.ts
@@ -1,8 +1,7 @@
 // migration 2023-08-13, 15:07
 import { Kysely, sql } from 'kysely'
-import type { Database } from '../index'
 
-export async function up(db: Kysely<Database>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
     await db.schema
         .alterTable('user')
         .addColumn('current_challenge', 'text')
@@ -13,7 +12,7 @@ export async function up(db: Kysely<Database>): Promise<void> {
     await db.schema.dropTable('webauthn').execute()
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {
+export async function down(db: Kysely<any>): Promise<void> {
     await db.schema
         .alterTable('user')
         .dropColumn('current_challenge')


### PR DESCRIPTION
This PR aims to fix migration files by passing `any` type, not my `Database` type as addressed in the doc.

> The only argument for the functions is an instance of Kysely<any>. It's important to use Kysely<any> and not Kysely<YourDatabase>. Migrations should never depend on the current code of your app because they need to work even when the app changes. Migrations need to be "frozen in time"

